### PR TITLE
Update syntax for templates string in Javascript

### DIFF
--- a/themes/horizon-bold.json
+++ b/themes/horizon-bold.json
@@ -148,7 +148,7 @@
     },
     {
       "name": "String",
-      "scope": ["string.quoted", "string.template", "punctuation.definition.string"],
+      "scope": ["string.quoted", "string.template", "punctuation.definition.string", "string.quasi"],
       "settings": {
         "foreground": "#FAB795E6"
       }

--- a/themes/horizon-italic.json
+++ b/themes/horizon-italic.json
@@ -148,7 +148,7 @@
     },
     {
       "name": "String",
-      "scope": ["string.quoted", "string.template", "punctuation.definition.string"],
+      "scope": ["string.quoted", "string.template", "punctuation.definition.string", "string.quasi"],
       "settings": {
         "foreground": "#FAB795E6"
       }

--- a/themes/horizon.json
+++ b/themes/horizon.json
@@ -148,7 +148,7 @@
     },
     {
       "name": "String",
-      "scope": ["string.quoted", "string.template", "punctuation.definition.string"],
+      "scope": ["string.quoted", "string.template", "punctuation.definition.string", "string.quasi"],
       "settings": {
         "foreground": "#FAB795E6"
       }


### PR DESCRIPTION
Hi,
I like your theme, but the bug with missing syntax for templates strings was so annoying.
I think we are saved now and everything else is working fine too.

## Before
![Screen Shot 2019-03-26 at 10 42 23](https://user-images.githubusercontent.com/17426143/54988027-e881b400-4fb5-11e9-81f4-5ab5acfa0787.png)

## After
![Screen Shot 2019-03-26 at 10 41 23](https://user-images.githubusercontent.com/17426143/54988045-ed466800-4fb5-11e9-838d-4da1036c0d70.png)
